### PR TITLE
init toml config for uv+hatchling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,9 @@ dependencies = [
     "arch>=7.2.0",
     "datetime>=5.5",
     "matplotlib>=3.10.6",
-    "numpy>=2.3.3",
+    "numpy<2", # AutoARIMA
     "pandas>=2.3.2",
-    "scipy>=1.16.2",
+    "scipy<1.16", # AutoARIMA
     "seaborn>=0.13.2",
     "sktime>=0.39.0",
     "statsmodels>=0.14.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "TS_Tell"
+version = "0.1.0"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+description = "A simple single-module package."
+readme = "README.md"
+authors = [
+    { name = "Matt Thompson", email = "" }
+]
+dependencies = [
+    "arch>=7.2.0",
+    "datetime>=5.5",
+    "matplotlib>=3.10.6",
+    "numpy>=2.3.3",
+    "pandas>=2.3.2",
+    "scipy>=1.16.2",
+    "seaborn>=0.13.2",
+    "sktime>=0.39.0",
+    "statsmodels>=0.14.5",
+    "typing>=3.10.0.0",
+    "whittaker-eilers>=0.2.0",
+]
+
+[tool.hatch.build.targets.wheel]
+include = ["TS_Tell.py"]
+# Configure setuptools to find your single-module package
+#[tool.uv_build.packages.find]
+#where = ["."]
+#include = ["TS_Tell"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,19 @@ dependencies = [
 
 [tool.hatch.build.targets.wheel]
 include = ["TS_Tell.py"]
+
+[tool.uv.workspace]
+members = [
+    ".",
+]
+
+[tool.uv.sources]
+ts-tell = { workspace = true }
+
+[dependency-groups]
+dev = [
+    "ts-tell",
+]
 # Configure setuptools to find your single-module package
 #[tool.uv_build.packages.find]
 #where = ["."]


### PR DESCRIPTION
@thompsonml pull this locally and try testing, setup dependencies using uv. 

Setup .venv
`uv sync`

Add deps as you go:
`uv add <pypi_package_name>`

You activate the .venv like usual
`source .venv/bin/activate`

I think also us uv run to use python without activating
`uv run pthon some_script`
